### PR TITLE
Use alias if the path has a corresponding alias

### DIFF
--- a/src/tab-labelizer.js
+++ b/src/tab-labelizer.js
@@ -24,6 +24,12 @@ function setTabName(tab) {
 }
 
 function getTabLabel(displayPath) {
+    for (var e = new Enumerator(DOpus.aliases); !e.atEnd(); e.moveNext()) {
+        var a = e.item();
+    
+        if(String(a.path) == displayPath)
+            return String(a);
+    }
     if (displayPath.substring(0, 6) === "ftp://") {
         return getFtpLabel(displayPath);
     }


### PR DESCRIPTION
If the user has already defined aliases in the Folder Aliases page of Favorites and Recent group, this script uses the alias name for displaying.

![dopus](https://github.com/PolarGoose/DirectoryOpus-TabLabelizer-plugin/assets/614159/9fdbd7b0-eae9-4ce8-b974-2e348e648d7e)

I did brief testing and it worked fine.